### PR TITLE
Updated Not-For-Profit clause to follow arc requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The official constitution of the UNSW Security Society.
     5.3 All financial transactions shall require two (2) signatures of members of the Executive;
     5.4 The club shall nominate three (3) members of the Executive as possible signatories for the account, one (1) of which must be the club Treasurer;
     5.5 The financial records of the club shall be open for inspection by Arc at all times.
-    5.6 The assets and income of the club shall be applied solely in furtherance of its above-mentioned objects and no portion shall be distributed directly or indirectly to the members of the club except as bona fide compensation for services rendered or expenses incurred on behalf of the club.
+    5.6 The assets and income of the organisation shall be applied solely in furtherance of its above-mentioned objects and no portion shall be distributed directly or indirectly to the members of the organisation except as bona fide compensation for services rendered or expenses incurred on behalf of the organisation.
 
 # 6 DISSOLUTION
     6.1 Dissolution of the club will occur after the following conditions have been met:


### PR DESCRIPTION
As per "Required Addition Not-For-Profit Clause" in Arc requirements, found at the following link: [https://www.arc.unsw.edu.au/clubs/club-forms/agms-and-reaffiliation-resources/changes-for-clubs-during-2024-reaffiliation](https://www.arc.unsw.edu.au/clubs/club-forms/agms-and-reaffiliation-resources/changes-for-clubs-during-2024-reaffiliation)