### PR TITLE
2025 AGM - Arc Required Changes & Updated Exec Positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The official constitution of the UNSW Security Society.
       1.3.3 Provide networking opportunities between students and companies in the security industry.
     1.4 In all matters not specifically dealt with herein, the procedures set out in the latest edition of Guide for Meetings and Organisations by N.E. Renton shall apply.
 
-## 2 DEFINITIONS
+# 2 DEFINITIONS
     2.1 For the purposes of this Constitution:
       2.1.1 The University shall mean the University of New South Wales;
       2.1.2 Arc shall mean Arc @ UNSW Limited;
@@ -24,6 +24,9 @@ The official constitution of the UNSW Security Society.
       2.1.9 An academic day shall mean a day during the first, second, or third term of the University's academic year which is not a Saturday, Sunday, Public Holiday or University Holiday; and
       2.1.10 Subjects shall mean units of study offered by the University in progression to the award of a degree.
     2.2 Unless a contrary statement appears in Section 9 of this Constitution, the club shall be bound by all the clauses in Section 3 to Section 8 of this Constitution.
+
+# 3 Not-for-profit clause
+    3.1 The assets and income of the organisation shall be applied solely in furtherance of its above-mentioned objects and no portion shall be distributed directly or indirectly to the members of the organisation except as bona fide compensation for services rendered or expenses incurred on behalf of the organization
 
 # 4 MEMBERSHIP
     4.1 Notwithstanding clause 4.1.1, contact details for members of your club are to remain with the Executive and Arc to have sole access. Contact details are not to be given or sold to any other person. 

--- a/README.md
+++ b/README.md
@@ -269,11 +269,11 @@ The official constitution of the UNSW Security Society.
       4.18.2 Online Elections
         4.18.2.1 At least two (2) weeks before the election:
           4.18.2.1.1 Nominations will open; and
-          4.18.2.1.2 Members will be notified that they need to sign up to the society on SpArc before voting begins to be eligible to vote.
+          4.18.2.1.2 Members will be notified that they need to sign up to the society on Rubric before voting begins to be eligible to vote.
         4.18.2.2 At least five (5) days before the election:
           4.18.2.2.1 Nominations will close;
           4.18.2.2.2 Candidates may start campaigning; and
-          4.18.2.2.3 Voting will begin, where official ballots shall only be sent to all members who have signed up to the society on SpArc.
+          4.18.2.2.3 Voting will begin, where official ballots shall only be sent to all members who have signed up to the society on Rubric.
         4.18.2.3 The results are to be declared at a General Meeting held within fourteen (14) days of the conclusion of voting.
     4.19 AGM Elections
       4.19.1 At least three (3) weeks prior to the AGM date, notice of the AGM and nomination procedure shall be given to members.

--- a/README.md
+++ b/README.md
@@ -11,82 +11,82 @@ The official constitution of the UNSW Security Society.
       1.3.3 Provide networking opportunities between students and companies in the security industry.
     1.4 In all matters not specifically dealt with herein, the procedures set out in the latest edition of Guide for Meetings and Organisations by N.E. Renton shall apply.
 
-## DEFINITIONS
-    1.5 For the purposes of this Constitution:
-      1.5.1 The University shall mean the University of New South Wales;
-      1.5.2 Arc shall mean Arc @ UNSW Limited;
-      1.5.3 Re-affiliation shall mean re-affiliation with Arc;
-      1.5.4 Members shall mean full members of the club;
-      1.5.5 Associate members shall mean associate members of the club;
-      1.5.6 The Executive shall mean the Executive of the club;
-      1.5.7 The Committee shall mean the Executive of the club as well as any member appointed by the Executive to fill a specific role;
-      1.5.8 The Annual General Meeting shall mean the Annual General Meeting of the club;
-      1.5.9 An academic day shall mean a day during the first, second, or third term of the University's academic year which is not a Saturday, Sunday, Public Holiday or University Holiday; and
-      1.5.10 Subjects shall mean units of study offered by the University in progression to the award of a degree.
-    1.6 Unless a contrary statement appears in Section 7 of this Constitution, the club shall be bound by all the clauses in Section 2 to Section 6 of this Constitution.
+## 2 DEFINITIONS
+    2.1 For the purposes of this Constitution:
+      2.1.1 The University shall mean the University of New South Wales;
+      2.1.2 Arc shall mean Arc @ UNSW Limited;
+      2.1.3 Re-affiliation shall mean re-affiliation with Arc;
+      2.1.4 Members shall mean full members of the club;
+      2.1.5 Associate members shall mean associate members of the club;
+      2.1.6 The Executive shall mean the Executive of the club;
+      2.1.7 The Committee shall mean the Executive of the club as well as any member appointed by the Executive to fill a specific role;
+      2.1.8 The Annual General Meeting shall mean the Annual General Meeting of the club;
+      2.1.9 An academic day shall mean a day during the first, second, or third term of the University's academic year which is not a Saturday, Sunday, Public Holiday or University Holiday; and
+      2.1.10 Subjects shall mean units of study offered by the University in progression to the award of a degree.
+    2.2 Unless a contrary statement appears in Section 9 of this Constitution, the club shall be bound by all the clauses in Section 3 to Section 8 of this Constitution.
 
-# 2 MEMBERSHIP
-    2.1 Notwithstanding clause 2.1.1, contact details for members of your club are to remain with the Executive and Arc to have sole access. Contact details are not to be given or sold to any other person. 
-        2.1.1 The Returning Officer specified in 4.17 shall have access to the contact details of those who choose to vote in an election. It must be made clear to the member that by choosing to vote, they are consenting to their contact details being given to the Returning Officer.
-    2.2 Full membership of the Club shall be open to all UNSW students, and they shall be required to pay an annual Club membership fee set by the Club Executive, and complete a membership form.
-    2.3 Associate membership shall be open to all persons who are not UNSW students, provided that they pay a membership fee that is set by the Club Executive, and they complete a membership form prepared by the Club Executive.
-    2.4 The duration of a person's membership shall be until the Club's next Annual General Meeting after they have become a member, or until the end of Week One in Term One of the University year after they have become a member, whichever is the latter.
-    2.5 The Club shall comply with Anti-Discrimination legislation in all its activities and procedures, including the granting of Club membership.
-    2.6 Notwithstanding clause 2.9, a member of a Club Executive may have their position declared vacant according to the procedures set out in Section 3.8.
-    2.7 Notwithstanding clauses 2.8 and 2.9, an Executive, a member or associate member of a Club may have their membership terminated after the following procedure is followed:
-        2.7.1 A motion is carried by the Executive, or the Executive is petitioned by twenty (20) members to instigate impeachment proceedings;
-        2.7.2 The members of the Club are notified of the proceedings formally as a motion on notice to an Extraordinary General Meeting under Section 2.2;
-        2.7.3 The member concerned is notified in writing of the procedures and reasons for proceedings at least seven (7) days prior to the meeting.
-        2.7.4 The member concerned is given five (5) minutes to speak against the motion at the Extraordinary General Meeting.
-        2.7.5 The motion is carried by the Extraordinary General Meeting.
-    2.8 Notwithstanding clause 2.9, an Executive, a member or associate member of a Club may have their membership terminated if the following occurs:
-        2.8.1 The person in question has acted in a way that has sabotaged the functions of the Club or disregarded the Constitution to the detriment of the Club's membership; and/or,
-        2.8.2 The person in question has instigated instances of bullying, harassment, assault and/or gendered violence to one or multiple individuals.
-        2.8.3 The Club has liaised with Arc about the person in question and Arc has determined the issue is of a serious nature.
-        2.8.4 That the Club has, in consultation with Arc, determined that a public EGM to remove the individual would cause undue harm to those that have been victimised or harmed.
-        2.8.5 Notice of a General Meeting must then be presented via the email they provided when signing up to the Club, to the person(s) in question, and the Executive, at least seven (7) days prior to the meeting.
-        2.8.6 This meeting must be held in-camera (privately) and the only people permitted to attend the meeting are:
-            2.8.6.1 Executive as listed within their Constitution, 
-            2.8.6.2 the person(s) in question,
-            2.8.6.3 a support person for each of the person(s) in question, as required 
-            2.8.6.4 Any member of Arc Clubs Management, as required
-        2.8.7 The person(s) in question must be afforded procedural fairness, including five (5) minutes to speak against the motion. (refer to Arc Clubs Policy Section E, 33.5 - 33.11) 
-        2.8.8 The motion is carried by the General Meeting.
-    2.9 Any member of a Club or Club Executive who believes they have been wrongly expelled may appeal to the Clubs Tribunal, who will arrive at the final resolution of the matter.
-    2.10 Appeals must be submitted in writing within seven (7) days of receiving the penalty and must include a justification for seeking an appeal. 
+# 4 MEMBERSHIP
+    4.1 Notwithstanding clause 4.1.1, contact details for members of your club are to remain with the Executive and Arc to have sole access. Contact details are not to be given or sold to any other person. 
+        4.1.1 The Returning Officer specified in 6.17 shall have access to the contact details of those who choose to vote in an election. It must be made clear to the member that by choosing to vote, they are consenting to their contact details being given to the Returning Officer.
+    4.2 Full membership of the Club shall be open to all UNSW students, and they shall be required to pay an annual Club membership fee set by the Club Executive, and complete a membership form.
+    4.3 Associate membership shall be open to all persons who are not UNSW students, provided that they pay a membership fee that is set by the Club Executive, and they complete a membership form prepared by the Club Executive.
+    4.4 The duration of a person's membership shall be until the Club's next Annual General Meeting after they have become a member, or until the end of Week One in Term One of the University year after they have become a member, whichever is the latter.
+    4.5 The Club shall comply with Anti-Discrimination legislation in all its activities and procedures, including the granting of Club membership.
+    4.6 Notwithstanding clause 4.9, a member of a Club Executive may have their position declared vacant according to the procedures set out in Section 5.8.
+    4.7 Notwithstanding clauses 4.8 and 4.9, an Executive, a member or associate member of a Club may have their membership terminated after the following procedure is followed:
+        4.7.1 A motion is carried by the Executive, or the Executive is petitioned by twenty (20) members to instigate impeachment proceedings;
+        4.7.2 The members of the Club are notified of the proceedings formally as a motion on notice to an Extraordinary General Meeting under Section 6.2;
+        4.7.3 The member concerned is notified in writing of the procedures and reasons for proceedings at least seven (7) days prior to the meeting.
+        4.7.4 The member concerned is given five (5) minutes to speak against the motion at the Extraordinary General Meeting.
+        4.7.5 The motion is carried by the Extraordinary General Meeting.
+    4.8 Notwithstanding clause 4.9, an Executive, a member or associate member of a Club may have their membership terminated if the following occurs:
+        4.8.1 The person in question has acted in a way that has sabotaged the functions of the Club or disregarded the Constitution to the detriment of the Club's membership; and/or,
+        4.8.2 The person in question has instigated instances of bullying, harassment, assault and/or gendered violence to one or multiple individuals.
+        4.8.3 The Club has liaised with Arc about the person in question and Arc has determined the issue is of a serious nature.
+        4.8.4 That the Club has, in consultation with Arc, determined that a public EGM to remove the individual would cause undue harm to those that have been victimised or harmed.
+        4.8.5 Notice of a General Meeting must then be presented via the email they provided when signing up to the Club, to the person(s) in question, and the Executive, at least seven (7) days prior to the meeting.
+        4.8.6 This meeting must be held in-camera (privately) and the only people permitted to attend the meeting are:
+            4.8.6.1 Executive as listed within their Constitution, 
+            4.8.6.2 the person(s) in question,
+            4.8.6.3 a support person for each of the person(s) in question, as required 
+            4.8.6.4 Any member of Arc Clubs Management, as required
+        4.8.7 The person(s) in question must be afforded procedural fairness, including five (5) minutes to speak against the motion. (refer to Arc Clubs Policy Section E, 33.5 - 33.11) 
+        4.8.8 The motion is carried by the General Meeting.
+    4.9 Any member of a Club or Club Executive who believes they have been wrongly expelled may appeal to the Clubs Tribunal, who will arrive at the final resolution of the matter.
+    4.10 Appeals must be submitted in writing within seven (7) days of receiving the penalty and must include a justification for seeking an appeal. 
 
-# 3 EXECUTIVE
-    3.1 The Executive of the club shall be elected from the full members at the Annual General Meeting and shall consist of at least:
-      3.1.1 Two (2) Co-Presidents
-      3.1.2 A Secretary;
-      3.1.3 A Treasurer; and
-      3.1.4 An Arc Delegate; and
-      3.1.5 A Grievance, Equity, Diversity, and Inclusion (GEDI) Officer.
-    3.2 One (1) member is permitted to hold two (2) Executive positions, provided that a minimum of three (3) different members shall remain on the Executive at all times, with the following exceptions:
-      3.2.1 Both Co-President positions may not be held by the same person;
-      3.2.2 Co-President and Treasurer may not be held by the same person;
-      3.2.3 Co-President and GEDI Officer may not be held by the same person.
-    3.3 Job sharing of any Executive position is not permitted.
-    3.4 The Executive shall be responsible for the following duties:
-      3.4.1 The activities of the club;
-      3.4.2 The finances of the club;
-      3.4.3 The maintenance and review of policies & procedures of the Club, including its Grievance Resolution Policy & Procedure.
-    3.5 The Executive is at all times bound by the decisions of a club Annual or Extraordinary General Meeting.
-    3.6 Any member of the Executive shall have their position declared vacant if they:
-      3.6.1 Die;
-      3.6.2 Cease to be a member of the club;
-      3.6.3 Cease to be a UNSW student;
-      3.6.4 Are absent from any three (3) consecutive meetings of the club without apology or leave; or
-        3.6.4.1 Unless exempted unanimously by the Executive.
-      3.6.5 The person fails to fulfil reasonable obligations delegated by:
-        3.6.5.1 The Constitution, or
-        3.6.5.2 The Executive, or
-        3.6.5.3 Any other supplementary regulations.
-        3.6.5.4 Unless exempted unanimously by the Executive.
-      3.6.6 Have their position declared vacant at an Extraordinary General Meeting.
-    3.7 Any vacancy on the club Executive must be filled at an Extraordinary General Meeting, via the procedures outlined in Section 4.
-    3.8 Duties of the following Executive positions shall include but not be limited to:
-      3.8.1 Co-Presidents
+# 5 EXECUTIVE
+    5.1 The Executive of the club shall be elected from the full members at the Annual General Meeting and shall consist of at least:
+      5.1.1 Two (2) Co-Presidents
+      5.1.2 A Secretary;
+      5.1.3 A Treasurer; and
+      5.1.4 An Arc Delegate; and
+      5.1.5 A Grievance, Equity, Diversity, and Inclusion (GEDI) Officer.
+    5.2 One (1) member is permitted to hold two (2) Executive positions, provided that a minimum of three (3) different members shall remain on the Executive at all times, with the following exceptions:
+      5.2.1 Both Co-President positions may not be held by the same person;
+      5.2.2 Co-President and Treasurer may not be held by the same person;
+      5.2.3 Co-President and GEDI Officer may not be held by the same person.
+    5.3 Job sharing of any Executive position is not permitted.
+    5.4 The Executive shall be responsible for the following duties:
+      5.4.1 The activities of the club;
+      5.4.2 The finances of the club;
+      5.4.3 The maintenance and review of policies & procedures of the Club, including its Grievance Resolution Policy & Procedure.
+    5.5 The Executive is at all times bound by the decisions of a club Annual or Extraordinary General Meeting.
+    5.6 Any member of the Executive shall have their position declared vacant if they:
+      5.6.1 Die;
+      5.6.2 Cease to be a member of the club;
+      5.6.3 Cease to be a UNSW student;
+      5.6.4 Are absent from any three (3) consecutive meetings of the club without apology or leave; or
+        5.6.4.1 Unless exempted unanimously by the Executive.
+      5.6.5 The person fails to fulfil reasonable obligations delegated by:
+        5.6.5.1 The Constitution, or
+        5.6.5.2 The Executive, or
+        5.6.5.3 Any other supplementary regulations.
+        5.6.5.4 Unless exempted unanimously by the Executive.
+      5.6.6 Have their position declared vacant at an Extraordinary General Meeting.
+    5.7 Any vacancy on the club Executive must be filled at an Extraordinary General Meeting, via the procedures outlined in Section 6.
+    5.8 Duties of the following Executive positions shall include but not be limited to:
+      5.8.1 Co-Presidents
         a) To chair all club, Committee, General and Annual General Meetings (held during their term) of the club or society;
         b) To oversee and coordinate the activities and administration of the club;
         c) To ensure that the elected officers of the club or society perform duties as laid down by the clubs' Constitution, through regular email updates, regularly advertised meetings, reports and notices and/or regular newsletters;
@@ -110,14 +110,14 @@ The official constitution of the UNSW Security Society.
         r) To ensure that motions made at any Meeting of the Club are reflective of the constitution;
         s) Other duties as in accordance with the Constitution of the club.
 
-      3.8.2 Secretary
+      5.8.2 Secretary
         a) To be responsible for receiving and replying to all correspondence on behalf of the club;
         b) To organise meetings, agendas (in consultation with the Co-Presidents), and minutes;
         c) To keep relevant club papers in order;
         d) To coordinate elections; and
         e) To maintain the membership list, updating when changes are made.
 
-      3.8.3 Treasurer
+      5.8.3 Treasurer
         a) To keep and maintain all club financial records;
         b) To hold cheque books, petty cash tins etc;
         c) To keep the club informed of its financial position (at meetings, through regular email reports, or regular newsletter;
@@ -133,7 +133,7 @@ The official constitution of the UNSW Security Society.
         m) To ensure that when smaller amounts of money are spent (petty cash) a receipt or docket must be obtained; and
         n) To ensure that under no circumstances are any expenses to be met without documentation.
 
-      3.8.4 Arc Delegate
+      5.8.4 Arc Delegate
         a) To be aware of the Arc funding system, its requirements and its possibilities for the club;
         b) To communicate with the Executive before and after each Arc Clubs General Meeting to pass on information (about grants etc);
         c) To liaise with Arc and the club's Executive;
@@ -143,7 +143,7 @@ The official constitution of the UNSW Security Society.
         g) To ensure that Arc is informed of any changes to the Executive; and
         h) To ensure that changes made to the constitution at an EGM or AGM are in line with Arc requirements.
 
-      3.8.5 Grievance, Equity, Diversity, and Inclusion (GEDI) Officer
+      5.8.5 Grievance, Equity, Diversity, and Inclusion (GEDI) Officer
         a) To be responsible for matters relating to grievances, including but not limited to:
              i. To receive complaints and grievances relating to the Club;
             ii. To investigate grievances (where necessary) and resolve grievances or make recommendations to the Club Executive on the resolution of grievances;
@@ -165,145 +165,145 @@ The official constitution of the UNSW Security Society.
         d) Run training and information sessions to upskill the executive team in understanding the Club's grievance policy; and
         e) Other relevant duties as required by the Club.
 
-    3.9 Committee Members
-      3.9.1 Committee positions are to be determined by the executive.
-      3.9.2 Committee positions are to be published and outlined to the society members in the Committee Regulations prior to appointing the committee members.
-        3.9.2.1 The Committee Regulations must outline a description of the position and any responsibilities, duties and obligations that position holds.
-      3.9.3 Committee members are to be appointed by a majority vote of the executive
-      3.9.4 Any member of the Committee shall have their position declared vacant if they:
-        3.9.4.1 Meet the criteria outlined in section 3.6; or
-        3.9.4.2 Are removed from their role by majority vote of the executive.
+    5.9 Committee Members
+      5.9.1 Committee positions are to be determined by the executive.
+      5.9.2 Committee positions are to be published and outlined to the society members in the Committee Regulations prior to appointing the committee members.
+        5.9.2.1 The Committee Regulations must outline a description of the position and any responsibilities, duties and obligations that position holds.
+      5.9.3 Committee members are to be appointed by a majority vote of the executive
+      5.9.4 Any member of the Committee shall have their position declared vacant if they:
+        5.9.4.1 Meet the criteria outlined in section 5.6; or
+        5.9.4.2 Are removed from their role by majority vote of the executive.
 
-# 4 MEETINGS
+# 6 MEETINGS
 
 ## Annual General Meetings
-    4.1 There shall be one (1) Annual General meeting every calendar year.
-    4.2 Notice in the form of an agenda for the Annual General Meeting shall be no less than fourteen (14) days, and is to be:
-      4.2.1 Given in writing to Arc; and
-      4.2.2 Given in writing to all club members, or upon approval by Arc displayed in a way that will guarantee an acceptable level of exposure among club members.
-    4.3 Quorum for the Annual General Meeting shall be:
-      4.3.1 Ten (10) or one half of the Club membership, whichever is the lesser, for all Clubs with less than 75 members, and for any other Club that has been active for less than 18 months from the time they first affiliated to Arc; or,
-      4.3.2 Fifteen (15) ordinary members for all Clubs with more than 75 members that have been active for more than 18 months from the time they first affiliated to Arc. An ordinary member is defined as a member of the Club that did not serve as Executive in the current year.
-    4.4 At an Annual General Meeting:
-      4.4.1 Reports shall be presented by at least one of the Co-Presidents and the Treasurer;
-      4.4.2 Full financial reports shall be presented and adopted;
-      4.4.3 Constitutional amendments and other motions on notice may be discussed and voted upon.
-      4.4.4 The Chair will hand over the meeting to the Returning Officer who will:
-        4.4.4.1 Hold elections for a new Executive; and/or if this has already happened online, 
-        4.4.4.2 Announce the winners and any other relevant information to attendees as required, before handing the meeting to the new, Incoming President, or in their absence, a duly elected Chair.
-    4.5 Full minutes of this meeting, including a list of the new Executive, written financial reports, and constitutional amendments, shall be forwarded to Arc within fourteen (14) days of the meeting.
+    6.1 There shall be one (1) Annual General meeting every calendar year.
+    6.2 Notice in the form of an agenda for the Annual General Meeting shall be no less than fourteen (14) days, and is to be:
+      6.2.1 Given in writing to Arc; and
+      6.2.2 Given in writing to all club members, or upon approval by Arc displayed in a way that will guarantee an acceptable level of exposure among club members.
+    6.3 Quorum for the Annual General Meeting shall be:
+      6.3.1 Ten (10) or one half of the Club membership, whichever is the lesser, for all Clubs with less than 75 members, and for any other Club that has been active for less than 18 months from the time they first affiliated to Arc; or,
+      6.3.2 Fifteen (15) ordinary members for all Clubs with more than 75 members that have been active for more than 18 months from the time they first affiliated to Arc. An ordinary member is defined as a member of the Club that did not serve as Executive in the current year.
+    6.4 At an Annual General Meeting:
+      6.4.1 Reports shall be presented by at least one of the Co-Presidents and the Treasurer;
+      6.4.2 Full financial reports shall be presented and adopted;
+      6.4.3 Constitutional amendments and other motions on notice may be discussed and voted upon.
+      6.4.4 The Chair will hand over the meeting to the Returning Officer who will:
+        6.4.4.1 Hold elections for a new Executive; and/or if this has already happened online, 
+        6.4.4.2 Announce the winners and any other relevant information to attendees as required, before handing the meeting to the new, Incoming President, or in their absence, a duly elected Chair.
+    6.5 Full minutes of this meeting, including a list of the new Executive, written financial reports, and constitutional amendments, shall be forwarded to Arc within fourteen (14) days of the meeting.
 
 ## Extraordinary General Meetings
-    4.6 There shall be Extraordinary General Meetings as the Executive sees fit or as petitioned under clause 4.8.
-    4.7 The format, procedures, notice and quorum for an Extraordinary General Meeting shall be the same as for an Annual General Meeting, except that Executive elections will not be held unless specifically notified.
-    4.8 To petition for an Extraordinary General Meeting, fifteen (15) members or half of the club membership, whichever is the lesser, must petition the Executive in writing.
-    4.9 Such a petitioned meeting must be held within twenty-one (21) days, but no sooner than seven (7) days.
-    4.10 There shall be other general meetings of the club as the Executive sees fit.
-    4.11 Proxies are not allowed at General, Annual General or Extraordinary General Meetings.
+    6.6 There shall be Extraordinary General Meetings as the Executive sees fit or as petitioned under clause 6.8.
+    6.7 The format, procedures, notice and quorum for an Extraordinary General Meeting shall be the same as for an Annual General Meeting, except that Executive elections will not be held unless specifically notified.
+    6.8 To petition for an Extraordinary General Meeting, fifteen (15) members or half of the club membership, whichever is the lesser, must petition the Executive in writing.
+    6.9 Such a petitioned meeting must be held within twenty-one (21) days, but no sooner than seven (7) days.
+    6.10 There shall be other general meetings of the club as the Executive sees fit.
+    6.11 Proxies are not allowed at General, Annual General or Extraordinary General Meetings.
 
 ## Meetings
-    4.12 General requirements for all meetings are as follows:
-      4.12.1 All Executive Resolutions (Voting) at meetings shall be subject to requirements outlined in Section 4.13; and
-      4.12.2 Approved minutes of Executive meetings shall be available to members;
-        4.12.2.1 Approved minutes may exclude, however is not limited to excluding: sponsorship discussions, committee nomination discussions and other internal private matters;
-    4.13 Meetings shall be conducted:
-      4.13.1 At least once per month;
-        4.13.1.1 Unless otherwise agreed upon by a majority of the executive
-      4.13.2 When called upon by a Co-President;
-      4.13.3 When requested by three (3) members of the Committee; and
-      4.13.4 In open session unless the Executive resolves to discuss a matter in closed session.
-        4.13.4.1 Open session meetings are to be publicised a week in advance to the meeting date.
-    4.14 Valid Executive Resolutions shall require:
-      4.14.1 That the matter to be dealt with by resolution be identified as an agenda item when notice of the relevant meeting is sent to executive members, unless by unanimous resolution of present voting executive members, it is declared the matter shall be dealt with;
-      4.14.2 That at least 50% of voting members of the executive be present when the resolution is passed;
-      4.14.3 A simple majority of present voting executive members to vote in favour of the resolution. Co-Presidents count as individual votes. In the event of a tie, the Co-Presidents shall have the casting vote if they are unanimous, otherwise the GEDI officer will have the casting vote. Executive members not present at the relevant meeting may nominate in advance another voting Executive member to act as their proxy. Each voting Executive may only carry one (1) proxy;
-      4.14.4 Constitutional changes must be in the form of a motion on notice to an Annual or Extraordinary General Meeting;
-      4.14.5 Constitutional changes passed at an Annual or Extraordinary General Meeting must be approved by Arc for the Club to remain affiliated with Arc.
+    6.12 General requirements for all meetings are as follows:
+      6.12.1 All Executive Resolutions (Voting) at meetings shall be subject to requirements outlined in Section 6.13; and
+      6.12.2 Approved minutes of Executive meetings shall be available to members;
+        6.12.2.1 Approved minutes may exclude, however is not limited to excluding: sponsorship discussions, committee nomination discussions and other internal private matters;
+    6.13 Meetings shall be conducted:
+      6.13.1 At least once per month;
+        6.13.1.1 Unless otherwise agreed upon by a majority of the executive
+      6.13.2 When called upon by a Co-President;
+      6.13.3 When requested by three (3) members of the Committee; and
+      6.13.4 In open session unless the Executive resolves to discuss a matter in closed session.
+        6.13.4.1 Open session meetings are to be publicised a week in advance to the meeting date.
+    6.14 Valid Executive Resolutions shall require:
+      6.14.1 That the matter to be dealt with by resolution be identified as an agenda item when notice of the relevant meeting is sent to executive members, unless by unanimous resolution of present voting executive members, it is declared the matter shall be dealt with;
+      6.14.2 That at least 50% of voting members of the executive be present when the resolution is passed;
+      6.14.3 A simple majority of present voting executive members to vote in favour of the resolution. Co-Presidents count as individual votes. In the event of a tie, the Co-Presidents shall have the casting vote if they are unanimous, otherwise the GEDI officer will have the casting vote. Executive members not present at the relevant meeting may nominate in advance another voting Executive member to act as their proxy. Each voting Executive may only carry one (1) proxy;
+      6.14.4 Constitutional changes must be in the form of a motion on notice to an Annual or Extraordinary General Meeting;
+      6.14.5 Constitutional changes passed at an Annual or Extraordinary General Meeting must be approved by Arc for the Club to remain affiliated with Arc.
 
 ## Elections
-    4.15 Elections of executive will be conducted at the Annual General Meeting (or Extraordinary General Meetings where relevant) following the requirements set out in this constitution.
-    4.16 At least one (1) Returning Officer must be appointed by the Executive prior to a General Meeting at which an election will take place.
-    4.17 The Returning Officers duties are as follows:
-      4.17.1 Ensure that they are at all times impartial and objective and cannot be determined to have a real or perceived conflict of interest by Club members, Executive or by Arc Clubs Management.
-      4.17.2 Ensure that all elections are run fairly and in line with the rules set out by this Club’s Constitution and according to Arc Clubs Policy and Procedure.
-      4.17.3 Prepare and circulate all notices of election, nominations, voting and proxies to be held as part of any General Meeting in which an election is to take place.
-      4.17.4 Provide all members with access to an email address that is designated for use by the Returning Officer over the course of their duties.
-      4.17.5 Accept all nominations submitted that satisfy the rules of this Club’s Constitution and Arc Clubs Policy and treat any defective or late nominations in the manner prescribed by this Club’s Constitution and/or Arc policy.
-      4.17.6 If voting is to take place online, ensure that the appointed Returning Officer(s) are the only person(s), alongside Arc Clubs Management, with access to the voting forms and spreadsheets.
-      4.17.7 If voting is to take place in person, ensure that they have provided all members with instructions surrounding proxies, have received any proxies via accepted channels and determined the validity of proxies submitted prior to the General Meeting taking place.
-      4.17.8 Runs the portion of the General Meeting pertaining to the election of candidates
-      4.17.9 Allows for at least 1 scrutineer per candidate, (who cannot be the candidate themselves) to be present for the counting of votes, if this is held in person, or for that person to be provided access to the voting sheets if the election was held online.
-      4.17.10 To present a report announcing all successful candidates following the conclusion of the voting process.
-      4.17.11 Where there is a clash between this Club’s Constitution and Arc Clubs Policy, Arc Clubs Policy takes precedence.
-    4.16 Elections requirements are stated as follows:
-      4.16.1 Optional preferential voting shall be used;
-      4.16.2 Voting for all positions shall be conducted simultaneously (where applicable);
-      4.16.3 Members who nominate themselves for candidacy for more than one (1) position must provide an order of preference;
-      4.16.4 If a candidate wins more than one (1) position, the candidate shall be elected to their most preferred position, and votes for the vacated position(s) shall be counted again (unless there are no other candidates in the vacated position).
-      4.16.5 If nominations are taken in advance:
-        4.16.5.1 All eligible members must receive notice of the nominations period before its commencement, as well as details of the nomination process.
-        4.16.5.2 Nominations must be open for at least seven (7) days.
-        4.16.5.3 Members who wish to submit themselves as nomination candidate:
-          4.16.5.3.1 Must do so directly to the Returning Officer; and
-          4.16.5.3.2 Must confirm their nomination by emailing the returning officer using their UNSW email, before voting begins.
-        4.16.5.4 Only the returning officer may view the list of nominations until nominations have closed.
-        4.16.5.5 At the start of the voting period:
-          4.16.5.5.1 An official ballot shall be sent to members;
-          4.16.5.5.2 The ballot will disclose the preferred position of each confirmed candidate; and
-          4.16.5.5.3 The order of candidates for each position on the ballot will be random.
-        4.16.5.6 For any position for which there are no confirmed candidates at the close of nominations, nominations for those positions will be valid if received at the General Meeting.
-    4.17 All election candidates:
-      4.17.1 Must not run in coalitions; and
-      4.17.2 May campaign for their positions subject to the following procedures:
-        4.17.2.1 The current or outgoing executives, and committee may not support or criticise any candidate for election other than themselves; and
-        4.17.2.2 The current or outgoing executives, and committee who are campaigning for themselves may not use any privileges or permissions from their position;
-      4.17.3 At the General Meeting at which the election was held (unless they are the only candidate for a position), will have their elected position given to the next candidate in line if:
-        4.17.3.1 They do not attend (unless the candidate has given an excuse), or
-        4.17.3.2 They wish to no longer accept their position.
-    4.18 Elections may take place as one of the following forms, provided they satisfy all existing election requirements as set out in this constitution and their requirements as set out below:
-      4.18.1 Ballot Elections
-        4.18.1.1 Nominations will be open at least one (1) week before the election, and close the day before the election;
-        4.18.1.2 Additional nominations received at the General Meeting are valid;
-        4.18.1.3 All present members shall be provided a paper ballot;
-        4.18.1.4 Candidates may campaign at the meeting before voting begins. If unable to do so, the Returning Officer shall read out their blurb, if any was provided.
-      4.18.2 Online Elections
-        4.18.2.1 At least two (2) weeks before the election:
-          4.18.2.1.1 Nominations will open; and
-          4.18.2.1.2 Members will be notified that they need to sign up to the society on Rubric before voting begins to be eligible to vote.
-        4.18.2.2 At least five (5) days before the election:
-          4.18.2.2.1 Nominations will close;
-          4.18.2.2.2 Candidates may start campaigning; and
-          4.18.2.2.3 Voting will begin, where official ballots shall only be sent to all members who have signed up to the society on Rubric.
-        4.18.2.3 The results are to be declared at a General Meeting held within fourteen (14) days of the conclusion of voting.
-    4.19 AGM Elections
-      4.19.1 At least three (3) weeks prior to the AGM date, notice of the AGM and nomination procedure shall be given to members.
-    4.20 After a new executive team is elected:
-      4.20.1 The previous executive team will retain delegated authority over activities run by their directors and subcommittee;
-      4.20.2 The incoming executive team may revoke this delegation by a majority vote among themselves; and
-      4.20.3 This authority will end at the conclusion of the final teaching period of the year, as defined by the University's main academic calendar.
+    6.15 Elections of executive will be conducted at the Annual General Meeting (or Extraordinary General Meetings where relevant) following the requirements set out in this constitution.
+    6.16 At least one (1) Returning Officer must be appointed by the Executive prior to a General Meeting at which an election will take place.
+    6.17 The Returning Officers duties are as follows:
+      6.17.1 Ensure that they are at all times impartial and objective and cannot be determined to have a real or perceived conflict of interest by Club members, Executive or by Arc Clubs Management.
+      6.17.2 Ensure that all elections are run fairly and in line with the rules set out by this Club’s Constitution and according to Arc Clubs Policy and Procedure.
+      6.17.3 Prepare and circulate all notices of election, nominations, voting and proxies to be held as part of any General Meeting in which an election is to take place.
+      6.17.4 Provide all members with access to an email address that is designated for use by the Returning Officer over the course of their duties.
+      6.17.5 Accept all nominations submitted that satisfy the rules of this Club’s Constitution and Arc Clubs Policy and treat any defective or late nominations in the manner prescribed by this Club’s Constitution and/or Arc policy.
+      6.17.6 If voting is to take place online, ensure that the appointed Returning Officer(s) are the only person(s), alongside Arc Clubs Management, with access to the voting forms and spreadsheets.
+      6.17.7 If voting is to take place in person, ensure that they have provided all members with instructions surrounding proxies, have received any proxies via accepted channels and determined the validity of proxies submitted prior to the General Meeting taking place.
+      6.17.8 Runs the portion of the General Meeting pertaining to the election of candidates
+      6.17.9 Allows for at least 1 scrutineer per candidate, (who cannot be the candidate themselves) to be present for the counting of votes, if this is held in person, or for that person to be provided access to the voting sheets if the election was held online.
+      6.17.10 To present a report announcing all successful candidates following the conclusion of the voting process.
+      6.17.11 Where there is a clash between this Club’s Constitution and Arc Clubs Policy, Arc Clubs Policy takes precedence.
+    6.16 Elections requirements are stated as follows:
+      6.16.1 Optional preferential voting shall be used;
+      6.16.2 Voting for all positions shall be conducted simultaneously (where applicable);
+      6.16.3 Members who nominate themselves for candidacy for more than one (1) position must provide an order of preference;
+      6.16.4 If a candidate wins more than one (1) position, the candidate shall be elected to their most preferred position, and votes for the vacated position(s) shall be counted again (unless there are no other candidates in the vacated position).
+      6.16.5 If nominations are taken in advance:
+        6.16.5.1 All eligible members must receive notice of the nominations period before its commencement, as well as details of the nomination process.
+        6.16.5.2 Nominations must be open for at least seven (7) days.
+        6.16.5.3 Members who wish to submit themselves as nomination candidate:
+          6.16.5.3.1 Must do so directly to the Returning Officer; and
+          6.16.5.3.2 Must confirm their nomination by emailing the returning officer using their UNSW email, before voting begins.
+        6.16.5.4 Only the returning officer may view the list of nominations until nominations have closed.
+        6.16.5.5 At the start of the voting period:
+          6.16.5.5.1 An official ballot shall be sent to members;
+          6.16.5.5.2 The ballot will disclose the preferred position of each confirmed candidate; and
+          6.16.5.5.3 The order of candidates for each position on the ballot will be random.
+        6.16.5.6 For any position for which there are no confirmed candidates at the close of nominations, nominations for those positions will be valid if received at the General Meeting.
+    6.17 All election candidates:
+      6.17.1 Must not run in coalitions; and
+      6.17.2 May campaign for their positions subject to the following procedures:
+        6.17.2.1 The current or outgoing executives, and committee may not support or criticise any candidate for election other than themselves; and
+        6.17.2.2 The current or outgoing executives, and committee who are campaigning for themselves may not use any privileges or permissions from their position;
+      6.17.3 At the General Meeting at which the election was held (unless they are the only candidate for a position), will have their elected position given to the next candidate in line if:
+        6.17.3.1 They do not attend (unless the candidate has given an excuse), or
+        6.17.3.2 They wish to no longer accept their position.
+    6.18 Elections may take place as one of the following forms, provided they satisfy all existing election requirements as set out in this constitution and their requirements as set out below:
+      6.18.1 Ballot Elections
+        6.18.1.1 Nominations will be open at least one (1) week before the election, and close the day before the election;
+        6.18.1.2 Additional nominations received at the General Meeting are valid;
+        6.18.1.3 All present members shall be provided a paper ballot;
+        6.18.1.4 Candidates may campaign at the meeting before voting begins. If unable to do so, the Returning Officer shall read out their blurb, if any was provided.
+      6.18.2 Online Elections
+        6.18.2.1 At least two (2) weeks before the election:
+          6.18.2.1.1 Nominations will open; and
+          6.18.2.1.2 Members will be notified that they need to sign up to the society on Rubric before voting begins to be eligible to vote.
+        6.18.2.2 At least five (5) days before the election:
+          6.18.2.2.1 Nominations will close;
+          6.18.2.2.2 Candidates may start campaigning; and
+          6.18.2.2.3 Voting will begin, where official ballots shall only be sent to all members who have signed up to the society on Rubric.
+        6.18.2.3 The results are to be declared at a General Meeting held within fourteen (14) days of the conclusion of voting.
+    6.19 AGM Elections
+      6.19.1 At least three (3) weeks prior to the AGM date, notice of the AGM and nomination procedure shall be given to members.
+    6.20 After a new executive team is elected:
+      6.20.1 The previous executive team will retain delegated authority over activities run by their directors and subcommittee;
+      6.20.2 The incoming executive team may revoke this delegation by a majority vote among themselves; and
+      6.20.3 This authority will end at the conclusion of the final teaching period of the year, as defined by the University's main academic calendar.
 
-# 5 FINANCE
-    5.1 The club shall hold an account with a financial institution approved by Arc;
-    5.2 The Executive must approve all accounts and expenditures for payment;
-    5.3 All financial transactions shall require two (2) signatures of members of the Executive;
-    5.4 The club shall nominate three (3) members of the Executive as possible signatories for the account, one (1) of which must be the club Treasurer;
-    5.5 The financial records of the club shall be open for inspection by Arc at all times.
-    5.6 The assets and income of the organisation shall be applied solely in furtherance of its above-mentioned objects and no portion shall be distributed directly or indirectly to the members of the organisation except as bona fide compensation for services rendered or expenses incurred on behalf of the organisation.
+# 7 FINANCE
+    7.1 The club shall hold an account with a financial institution approved by Arc;
+    7.2 The Executive must approve all accounts and expenditures for payment;
+    7.3 All financial transactions shall require two (2) signatures of members of the Executive;
+    7.4 The club shall nominate three (3) members of the Executive as possible signatories for the account, one (1) of which must be the club Treasurer;
+    7.5 The financial records of the club shall be open for inspection by Arc at all times.
+    7.6 The assets and income of the organisation shall be applied solely in furtherance of its above-mentioned objects and no portion shall be distributed directly or indirectly to the members of the organisation except as bona fide compensation for services rendered or expenses incurred on behalf of the organisation.
 
-# 6 DISSOLUTION
-    6.1 Dissolution of the club will occur after the following conditions have been met:
-      6.1.1 An Extraordinary General Meeting is petitioned in writing as set out in 4.8;
-      6.1.2 Procedures for notification as set out in 4.2 are followed, and the reasons for the proposed dissolution are included with the notification to Arc;
-      6.1.3 Quorum for the meeting to dissolve the club shall be twenty (20) members or three-quarters of the club membership, whichever is the lesser;
-      6.1.4 No other business may be conducted at the meeting to dissolve the club;
-      6.1.5 After the petitioning body has stated its case any opposition must be given the opportunity to reply, with at least ten (10) minutes set aside for this purpose;
-      6.1.6 A vote is taken and the motion to dissolve lapses if opposed by fifteen (15) or more members of the club;
-      6.1.7 If the motion to dissolve is carried, Arc must be notified within fourteen (14) days;
-    6.2 Dissolution of the club will also occur if the club has been financially and administratively inactive for a period of eighteen (18) months;
-    6.3 On dissolution of the club, the club is not to distribute assets to members. All assets are to be distributed to an organisation with similar goals or objectives that also prohibits the distribution of assets to members. This organisation may be nominated at the dissolution meeting of the club. If no other legitimate club or organisation is nominated, Arc will begin procedures to recover any property, monies or records belonging to the club which it perceives would be useful to other Arc-affiliated clubs. The club will be given twenty one (21) days to forward all relevant items to Arc before any action is instigated.
+# 8 DISSOLUTION
+    8.1 Dissolution of the club will occur after the following conditions have been met:
+      8.1.1 An Extraordinary General Meeting is petitioned in writing as set out in 6.8;
+      8.1.2 Procedures for notification as set out in 6.2 are followed, and the reasons for the proposed dissolution are included with the notification to Arc;
+      8.1.3 Quorum for the meeting to dissolve the club shall be twenty (20) members or three-quarters of the club membership, whichever is the lesser;
+      8.1.4 No other business may be conducted at the meeting to dissolve the club;
+      8.1.5 After the petitioning body has stated its case any opposition must be given the opportunity to reply, with at least ten (10) minutes set aside for this purpose;
+      8.1.6 A vote is taken and the motion to dissolve lapses if opposed by fifteen (15) or more members of the club;
+      8.1.7 If the motion to dissolve is carried, Arc must be notified within fourteen (14) days;
+    8.2 Dissolution of the club will also occur if the club has been financially and administratively inactive for a period of eighteen (18) months;
+    8.3 On dissolution of the club, the club is not to distribute assets to members. All assets are to be distributed to an organisation with similar goals or objectives that also prohibits the distribution of assets to members. This organisation may be nominated at the dissolution meeting of the club. If no other legitimate club or organisation is nominated, Arc will begin procedures to recover any property, monies or records belonging to the club which it perceives would be useful to other Arc-affiliated clubs. The club will be given twenty one (21) days to forward all relevant items to Arc before any action is instigated.
 
-# 7 ADDITIONS
-    7.1 Any digital form sent from the society which requires a response must provide a submission receipt unless anonymously completed.
+# 9 ADDITIONS
+    9.1 Any digital form sent from the society which requires a response must provide a submission receipt unless anonymously completed.
 
-    Please number any further additions or alterations to this Constitution starting with 7.2, and ensure that a copy is submitted to Arc with your affiliation. Additions or alterations to this Constitution do not become valid unless ratified by Arc.
+    Please number any further additions or alterations to this Constitution starting with 9.2, and ensure that a copy is submitted to Arc with your affiliation. Additions or alterations to this Constitution do not become valid unless ratified by Arc.
 

--- a/README.md
+++ b/README.md
@@ -60,36 +60,40 @@ The official constitution of the UNSW Security Society.
 
 # 5 EXECUTIVE
     5.1 The Executive of the club shall be elected from the full members at the Annual General Meeting and shall consist of at least:
-      5.1.1 Two (2) Co-Presidents
-      5.1.2 A Secretary;
-      5.1.3 A Treasurer; and
-      5.1.4 An Arc Delegate; and
-      5.1.5 A Grievance, Equity, Diversity, and Inclusion (GEDI) Officer.
-    5.2 One (1) member is permitted to hold two (2) Executive positions, provided that a minimum of three (3) different members shall remain on the Executive at all times, with the following exceptions:
-      5.2.1 Both Co-President positions may not be held by the same person;
-      5.2.2 Co-President and Treasurer may not be held by the same person;
-      5.2.3 Co-President and GEDI Officer may not be held by the same person.
-    5.3 Job sharing of any Executive position is not permitted.
-    5.4 The Executive shall be responsible for the following duties:
-      5.4.1 The activities of the club;
-      5.4.2 The finances of the club;
-      5.4.3 The maintenance and review of policies & procedures of the Club, including its Grievance Resolution Policy & Procedure.
-    5.5 The Executive is at all times bound by the decisions of a club Annual or Extraordinary General Meeting.
-    5.6 Any member of the Executive shall have their position declared vacant if they:
-      5.6.1 Die;
-      5.6.2 Cease to be a member of the club;
-      5.6.3 Cease to be a UNSW student;
-      5.6.4 Are absent from any three (3) consecutive meetings of the club without apology or leave; or
-        5.6.4.1 Unless exempted unanimously by the Executive.
-      5.6.5 The person fails to fulfil reasonable obligations delegated by:
-        5.6.5.1 The Constitution, or
-        5.6.5.2 The Executive, or
-        5.6.5.3 Any other supplementary regulations.
-        5.6.5.4 Unless exempted unanimously by the Executive.
-      5.6.6 Have their position declared vacant at an Extraordinary General Meeting.
-    5.7 Any vacancy on the club Executive must be filled at an Extraordinary General Meeting, via the procedures outlined in Section 6.
-    5.8 Duties of the following Executive positions shall include but not be limited to:
-      5.8.1 Co-Presidents
+      5.1.1 A President;
+      5.1.2 A Vice President of Externals;
+      5.1.3 A Vice President of Internals;
+      5.1.4 A Vice President of Technicals;
+      5.1.5 A Treasurer; and
+      5.1.6 A Grievance, Equity, Diversity, and Inclusion (GEDI) Officer.
+    5.2 The term of office for each Executive elected at an AGM shall start at the conclusion of Term 3 in the current year (unless voted otherwise by the incoming executives under clause 6.20) and continue until the conclusion of Term 3 in the subsequent calendar year (or they lose authority under clause 6.20).
+    5.3 Any Executive elected at an EGM will serve from the date of their election until the end of the next Term 3 in any given calendar year.
+    5.4 One (1) member is permitted to hold two (2) Executive positions, provided that a minimum of three (3) different members shall remain on the Executive at all times, with the following exceptions:
+      5.4.1 President and Treasurer may not be held by the same person;
+      5.4.2 President and GEDI Officer may not be held by the same person.
+    5.5 Job sharing of any Executive position is not permitted.
+    5.6 The Executive shall be responsible for the following duties:
+      5.6.1 The activities of the club;
+      5.6.2 The finances of the club;
+      5.6.3 Appointing members to the Committee;
+      5.6.4 The maintenance and review of policies & procedures of the Club, including its Grievance Resolution Policy & Procedure.
+    5.7 The Executive is at all times bound by the decisions of a club Annual or Extraordinary General Meeting.
+    5.8 Any member of the Executive shall have their position declared vacant if they:
+      5.8.1 Die;
+      5.8.2 Cease to be a member of the club;
+      5.8.3 Cease to be a UNSW student;
+      5.8.4 Are absent from any three (3) consecutive meetings of the club without apology or leave; or
+        5.8.4.1 Unless exempted unanimously by the Executive.
+      5.8.5 The person fails to fulfil reasonable obligations delegated by:
+        5.8.5.1 The Constitution, or
+        5.8.5.2 The Executive, or
+        5.8.5.3 Any other supplementary regulations.
+        5.8.5.4 Unless exempted unanimously by the Executive.
+      5.8.6 Have their position declared vacant at an Extraordinary General Meeting.
+    5.9 Any vacancy on the club Executive must be filled at an Extraordinary General Meeting, via the procedures outlined in Section 4.
+    5.10 Duties of the following Executive positions shall include but not be limited to:
+
+    5.10.1 President
         a) To chair all club, Committee, General and Annual General Meetings (held during their term) of the club or society;
         b) To oversee and coordinate the activities and administration of the club;
         c) To ensure that the elected officers of the club or society perform duties as laid down by the clubs' Constitution, through regular email updates, regularly advertised meetings, reports and notices and/or regular newsletters;
@@ -113,14 +117,25 @@ The official constitution of the UNSW Security Society.
         r) To ensure that motions made at any Meeting of the Club are reflective of the constitution;
         s) Other duties as in accordance with the Constitution of the club.
 
-      5.8.2 Secretary
-        a) To be responsible for receiving and replying to all correspondence on behalf of the club;
-        b) To organise meetings, agendas (in consultation with the Co-Presidents), and minutes;
-        c) To keep relevant club papers in order;
-        d) To coordinate elections; and
-        e) To maintain the membership list, updating when changes are made.
+      5.10.2 Vice President of Externals
+        a) To organise external meetings, agendas (in consultation with the President), and meeting minutes;
+        b) To act as the delegate of the club to external bodies, and be responsible for managing relations with external entities and organisations;
+        c) To be responsible for receiving and replying to all correspondence on behalf of the club;
+        d) Manage and oversee the Club’s presence on social and professional media platforms.
 
-      5.8.3 Treasurer
+      5.10.3 Vice President of Internals
+        a) To organise internal meetings, agendas (in consultation with the President), and meeting minutes;
+        b) To keep relevant club papers in order;
+        c) Administer and coordinate all elections of the Club in accordance with this Constitution;
+        d) Administer and coordinate voting procedures and documentation of dispute resolution by vote in accordance with the constitution.
+
+      5.10.4 Vice President of Technicals
+        a) To maintain, oversee, and improve upon the Club’s digital infrastructure;
+        b) To ensure that the Club's infrastructure is secure, reliable, and compliant with University and Arc requirements, including data protection and privacy obligations;
+        c) To manage and coordinate technical projects on behalf of the society, ensuring that objectives are clearly defined, progress is tracked, and deliverables are met on time.
+        d) To fully document and hand over technical systems, accounts, and infrastructure to their successor at the end of their term, ensuring continuity of operations.
+
+      5.10.5 Treasurer
         a) To keep and maintain all club financial records;
         b) To hold cheque books, petty cash tins etc;
         c) To keep the club informed of its financial position (at meetings, through regular email reports, or regular newsletter;
@@ -135,18 +150,16 @@ The official constitution of the UNSW Security Society.
         l) To ensure that club funds are not misused at any time;
         m) To ensure that when smaller amounts of money are spent (petty cash) a receipt or docket must be obtained; and
         n) To ensure that under no circumstances are any expenses to be met without documentation.
+        o) To be aware of the Arc funding system, its requirements and its possibilities for the club;
+        p) To communicate with the Executive before and after each Arc Clubs General Meeting to pass on information (about grants etc);
+        q) To liaise with Arc and the club's Executive;
+        r) To have a good working knowledge of Arc forms;
+        s) To clear out the club's pigeonhole in the Arc Resource Centre at least every two (2) weeks;
+        t) To attend Arc Clubs General Meetings or nominate a fellow club member to attend on your behalf, or send advance apologies (taking the form of a written note detailing your name, club, and the date of the meeting you can not attend);
+        u) To ensure that Arc is informed of any changes to the Executive; and
+        v) To ensure that changes made to the constitution at an EGM or AGM are in line with Arc requirements.
 
-      5.8.4 Arc Delegate
-        a) To be aware of the Arc funding system, its requirements and its possibilities for the club;
-        b) To communicate with the Executive before and after each Arc Clubs General Meeting to pass on information (about grants etc);
-        c) To liaise with Arc and the club's Executive;
-        d) To have a good working knowledge of Arc forms;
-        e) To clear out the club's pigeonhole in the Arc Resource Centre at least every two (2) weeks;
-        f) To attend Arc Clubs General Meetings or nominate a fellow club member to attend on your behalf, or send advance apologies (taking the form of a written note detailing your name, club, and the date of the meeting you can not attend);
-        g) To ensure that Arc is informed of any changes to the Executive; and
-        h) To ensure that changes made to the constitution at an EGM or AGM are in line with Arc requirements.
-
-      5.8.5 Grievance, Equity, Diversity, and Inclusion (GEDI) Officer
+      5.10.6 Grievance, Equity, Diversity, and Inclusion (GEDI) Officer
         a) To be responsible for matters relating to grievances, including but not limited to:
              i. To receive complaints and grievances relating to the Club;
             ii. To investigate grievances (where necessary) and resolve grievances or make recommendations to the Club Executive on the resolution of grievances;
@@ -168,14 +181,14 @@ The official constitution of the UNSW Security Society.
         d) Run training and information sessions to upskill the executive team in understanding the Club's grievance policy; and
         e) Other relevant duties as required by the Club.
 
-    5.9 Committee Members
-      5.9.1 Committee positions are to be determined by the executive.
-      5.9.2 Committee positions are to be published and outlined to the society members in the Committee Regulations prior to appointing the committee members.
-        5.9.2.1 The Committee Regulations must outline a description of the position and any responsibilities, duties and obligations that position holds.
-      5.9.3 Committee members are to be appointed by a majority vote of the executive
-      5.9.4 Any member of the Committee shall have their position declared vacant if they:
-        5.9.4.1 Meet the criteria outlined in section 5.6; or
-        5.9.4.2 Are removed from their role by majority vote of the executive.
+    5.11 Committee Members
+      5.11.1 Committee positions are to be determined by the executive.
+      5.11.2 Committee positions are to be published and outlined to the society members in the Committee Regulations prior to appointing the committee members.
+        5.11.2.1 The Committee Regulations must outline a description of the position and any responsibilities, duties and obligations that position holds.
+      5.11.3 Committee members are to be appointed by a majority vote of the executive
+      5.11.4 Any member of the Committee shall have their position declared vacant if they:
+        5.11.4.1 Meet the criteria outlined in section 5.8; or
+        5.11.4.2 Are removed from their role by majority vote of the executive.
 
 # 6 MEETINGS
 


### PR DESCRIPTION
- Change SpArc to Rubric (the new platform being used by Arc @ UNSW)
- Add not-for-profit clause, [as required by Arc](https://www.arc.unsw.edu.au/clubs/club-forms/agms-and-reaffiliation-resources/changes-for-clubs-during-2024-reaffiliation/#:~:text=All%20club%20Constitutions%20must%20contain%20the%20clause%20shown%20below%20in%20its%20entirety%20without%20edits)
- Update section numbers to mirror the Arc model constitution (make Definitions section 2. rather than part of section 1., insert not-for-profit clause as section 3, and increment all later sections by 2)
- Update executive positions - remove Secretary and Arc Delegate, add: Vice President of Externals, Vice President of Internals, and Vice President of Technicals
- Clarify the term of office as per Arc guidelines, with minor modifications to work with the clause added last year about delegated responsibility of outgoing executives